### PR TITLE
feat: add skip-on-empty feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `git-message`: Commit message that is used when committing the changelog.
 - **Optional** `preset`: Preset that is used from conventional commits. Default `angular`.
 - **Optional** `tag-prefix`: Prefix for the git tags. Default `v`.
-- **Optional** `output-file`: File to output the changelog to. Default `CHANGELOG.md`, when providing `false` no file will be generated / updated.
+- **Optional** `output-file`: File to output the changelog to. Default `CHANGELOG.md`, when providing `'false'` no file will be generated / updated.
 - **Optional** `release-count`: Number of releases to preserve in changelog. Default `5`, use `0` to regenerate all.
 - **Optional** `package-json`: The path to the package.json to use. Default `./package.json`.
+- **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occured when you push `chore` commit with `angular` for example. Default `'false'`.
 
 ## Outputs
 
@@ -18,10 +19,12 @@ This action will bump version, tag commit and generate a changelog with conventi
 - `clean_changelog`: The generated changelog for the new version without the version name in it (Better for Github releases)
 - `version`: The new version.
 - `tag`: The name of the generated tag.
+- `skipped`: Boolean (`'true'` or `'false'`) specifying if this step have been skipped
 
 ## Example usages
 
 Uses all the defaults
+
 ```yaml
 - name: Conventional Changelog Action
   uses: TriPSs/conventional-changelog-action@v2
@@ -30,6 +33,7 @@ Uses all the defaults
 ```
 
 Overwrite everything
+
 ```yaml
 - name: Conventional Changelog Action
   uses: TriPSs/conventional-changelog-action@v2
@@ -44,6 +48,7 @@ Overwrite everything
 ```
 
 No file changelog
+
 ```yaml
 - name: Conventional Changelog Action
   uses: TriPSs/conventional-changelog-action@v2
@@ -53,6 +58,7 @@ No file changelog
 ```
 
 Github releases
+
 ```yaml
 - name: Conventional Changelog Action
   id: changelog
@@ -60,9 +66,11 @@ Github releases
   with:
     github-token: ${{ secrets.github_token }}
     output-file: 'false'
+    skip-on-empty: 'true'
 
 - name: Create Release
   uses: actions/create-release@v1
+  if: ${{ !steps.changelog.outputs.skipped  }}
   env:
    GITHUB_TOKEN: ${{ secrets.github_token }}
   with:

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,11 @@ inputs:
     default: './package.json'
     required: false
 
+  skip-on-empty:
+    description: 'Do nothing when the changelog from the latest release is empty'
+    default: 'false'
+    required: false
+
 outputs:
   changelog:
     description: 'The generated changelog for the new version'
@@ -53,3 +58,5 @@ outputs:
     description: 'The new version'
   tag:
     description: 'The name of the generated tag'
+  skipped:
+    description: 'boolean to check if this step have been skipped'

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ async function run() {
     const outputFile = core.getInput('output-file')
     const releaseCount = core.getInput('release-count')
     const packageJsonToUse = core.getInput('package-json')
+    const skipOnEmptyRelease = core.getInput('skip-on-empty').toLowerCase() === 'true'
 
     core.info(`Using "${preset}" preset`)
     core.info(`Using "${commitMessage}" as commit message`)
@@ -24,49 +25,59 @@ async function run() {
     core.info('Pull to make sure we have the full git history')
     await git.pull()
 
-    conventionalRecommendedBump({ preset, tagPrefix }, async(error, recommendation) => {
+    conventionalRecommendedBump({ preset, tagPrefix }, async (error, recommendation) => {
       if (error) {
         core.setFailed(error.message)
-
-      } else {
-        core.info(`Recommended release type: ${recommendation.releaseType}`)
-
-        // Bump the version in the package.json
-        const jsonPackage = packageJson.bump(
-          packageJson.get(),
-          recommendation.releaseType,
-        )
-
-        // Update the package.json file
-        packageJson.update(jsonPackage)
-
-        core.info(`New version: ${jsonPackage.version}`)
-
-        // If output file === 'false' we don't write it to file
-        if (outputFile !== 'false') {
-          // Generate the changelog
-          await changelog.generateFileChangelog(tagPrefix, preset, jsonPackage, outputFile, releaseCount)
-        }
-
-        const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, jsonPackage, 1)
-        core.info('Changelog generated')
-        core.info(stringChangelog)
-
-        core.info('Push all changes')
-
-        // Add changed files to git
-        await git.add('.')
-        await git.commit(commitMessage.replace('{version}', `${tagPrefix}${jsonPackage.version}`))
-        await git.createTag(`${tagPrefix}${jsonPackage.version}`)
-        await git.push()
-
-        // Set outputs so other actions (for example actions/create-release) can use it
-        core.setOutput('changelog', stringChangelog)
-        // Removes the version number from the changelog
-        core.setOutput('clean_changelog', stringChangelog.split('\n').slice(3).join('\n'))
-        core.setOutput('version', jsonPackage.version)
-        core.setOutput('tag', `${tagPrefix}${jsonPackage.version}`)
+        return
       }
+
+      core.info(`Recommended release type: ${recommendation.releaseType}`)
+      recommendation.reason && core.info(`because: ${recommendation.reason}`)
+
+      // Bump the version in the package.json
+      const jsonPackage = packageJson.bump(
+        packageJson.get(),
+        recommendation.releaseType,
+      )
+
+      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, jsonPackage, 1)
+      core.info('Changelog generated')
+      core.info(stringChangelog)
+
+      const cleanChangelog = stringChangelog.split('\n').slice(3).join('\n').trim()
+
+      if (skipOnEmptyRelease && cleanChangelog === '') {
+        core.info('Generated changelog is empty so we skip this step')
+        core.setOutput('skipped', 'true')
+        return
+      }
+
+      // Update the package.json file
+      packageJson.update(jsonPackage)
+
+      core.info(`New version: ${jsonPackage.version}`)
+
+      // If output file === 'false' we don't write it to file
+      if (outputFile !== 'false') {
+        // Generate the changelog
+        await changelog.generateFileChangelog(tagPrefix, preset, jsonPackage, outputFile, releaseCount)
+      }
+
+      core.info('Push all changes')
+
+      // Add changed files to git
+      await git.add('.')
+      await git.commit(commitMessage.replace('{version}', `${tagPrefix}${jsonPackage.version}`))
+      await git.createTag(`${tagPrefix}${jsonPackage.version}`)
+      await git.push()
+
+      // Set outputs so other actions (for example actions/create-release) can use it
+      core.setOutput('changelog', stringChangelog)
+      // Removes the version number from the changelog
+      core.setOutput('clean_changelog', cleanChangelog)
+      core.setOutput('version', jsonPackage.version)
+      core.setOutput('tag', `${tagPrefix}${jsonPackage.version}`)
+      core.setOutput('skipped', 'false')
     })
 
   } catch (error) {


### PR DESCRIPTION
Hi !
While I was playing with your action I've encountered an issue where I was generating too many releases with en empty changelog. (ie: I made some small commit to trying improve my github action workflow with only `chore` labelled commit)
So I've implemented a way to skip all the process made when such a case occurred !

Let me know if you are interested with my modifications/feature proposal, thanks 😄