### PR TITLE
feat: add pre-commit script file (hook)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           ENV: 'dont-use-git'
         with:
           github-token: ${{ secrets.github_token }}
-          pre-commit: ${{ github.workspace }}/test/pre-commit.js
+          pre-commit: test/pre-commit.js
           skip-on-empty: 'false'
 
       - run: test -f pre-commit.test.json || (echo should be here && exit 1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,29 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
 
+  test-pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: test -f pre-commit.test.json && (echo should not be here yet && exit 1) || exit 0
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          pre-commit: ${{ github.workspace }}/test/pre-commit.js
+          skip-on-empty: 'false'
+
+      - run: test -f pre-commit.test.json || (echo should be here && exit 1)
+      - run: cat pre-commit.test.json
+
   test-git:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ This action will bump version, tag commit and generate a changelog with conventi
 > version is already known and a new changelog has been generated. You can run any chores across your
 > repository that should be added and commited with the release commit.
 
-An absolute path to the `.js` script file must be provided when specifying the `pre-commit` hook. File
-should contain all its dependencies bundled in itself just like for the webapp.
+Specified path could be relative or absolute. If it is relative, then it will be based on the `GITHUB_WORKSPACE` path.
 
 Script should:
 - be a CommonJS module
 - have a single export: `exports.preCommit = (props) => { /* ... */ }`
 - not have any return value
-- be bundled
+- be bundled (contain all dependencies in itself, just like the bundled webapp)
 
 `preCommit` function can be `async`.
 
@@ -41,13 +40,14 @@ Following props will be passed to the function as a single parameter:
 
 ```typescript
 interface Props {
-  workspace: string; // same as process.env.GITHUB_WORKSPACE
   tag: string; // Next tag e.g. v1.12.3
   version: string; // Next version e.g. 1.12.3
 }
 
 export function preCommit(props: Props): void {}
 ```
+
+A bunch of useful environment variables are available to the script with `process.env`. See [docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables) to learn more.
 
 ## Outputs
 
@@ -126,7 +126,7 @@ Use a pre-commit hook
   uses: TriPSs/conventional-changelog-action@v3
   with:
     github-token: ${{ secrets.github_token }}
-    pre-commit: ${{ github.workspace }}/some/path/pre-commit.js # requires absolute path
+    pre-commit: some/path/pre-commit.js
 ```
 
 Github releases

--- a/README.md
+++ b/README.md
@@ -18,6 +18,36 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occured when you push `chore` commit with `angular` for example. Default `'false'`.
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
 - **Optional** `skip-commit`: Do create a release commit. Default `'false'`.
+- **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
+
+### Pre-Commit hook
+
+> Function in a specified file will be run right before the git-add-git-commit phase, when the next
+> version is already known and a new changelog has been generated. You can run any chores across your
+> repository that should be added and commited with the release commit.
+
+An absolute path to the `.js` script file must be provided when specifying the `pre-commit` hook. File
+should contain all its dependencies bundled in itself just like for the webapp.
+
+Script should:
+- be a CommonJS module
+- have a single export: `exports.preCommit = (props) => { /* ... */ }`
+- not have any return value
+- be bundled
+
+`preCommit` function can be `async`.
+
+Following props will be passed to the function as a single parameter:
+
+```typescript
+interface Props {
+  workspace: string; // same as process.env.GITHUB_WORKSPACE
+  tag: string; // Next tag e.g. v1.12.3
+  version: string; // Next version e.g. 1.12.3
+}
+
+export function preCommit(props: Props): void {}
+```
 
 ## Outputs
 
@@ -89,6 +119,16 @@ Use a custom file for versioning
     version-file: 'my-custom-file.yaml'
 ```
 
+Use a pre-commit hook
+
+```yaml
+- name: Conventional Changelog Action
+  uses: TriPSs/conventional-changelog-action@v3
+  with:
+    github-token: ${{ secrets.github_token }}
+    pre-commit: ${{ github.workspace }}/some/path/pre-commit.js # requires absolute path
+```
+
 Github releases
 
 ```yaml
@@ -129,6 +169,9 @@ $ act -j test-yaml -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s gith
 
 # To run / toml git versioning
 $ act -j test-toml -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
+
+# To run pre-commit test
+$ act -j test-pre-commit -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
 ```
 
 ## [License](./LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     default: 'false'
     required: false
 
+  pre-commit:
+    description: 'Path to the pre-commit script file'
+    required: false
+
 
 outputs:
   changelog:

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ async function run() {
       if (!skipCommit) {
         // Add changed files to git
         if (preCommit) {
-          await require(preCommit).preCommit({
+          await require(path.resolve(preCommit)).preCommit({
             tag: gitTag,
             version: versioning.newVersion,
           })

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ async function run() {
     const gitUserEmail = core.getInput('git-user-email')
     const tagPrefix = core.getInput('tag-prefix')
     const preset = core.getInput('preset')
+    const preCommit = core.getInput('pre-commit')
     const outputFile = core.getInput('output-file')
     const releaseCount = core.getInput('release-count')
     const versionFile = core.getInput('version-file')
@@ -30,6 +31,10 @@ async function run() {
     core.info(`Using "${versionPath}" as version path`)
     core.info(`Using "${tagPrefix}" as tag prefix`)
     core.info(`Using "${outputFile}" as output file`)
+
+    if (preCommit) {
+      core.info(`Using "${preCommit}" as pre-commit script`)
+    }
 
     core.info(`Skipping empty releases is "${skipEmptyRelease ? 'enabled' : 'disabled'}"`)
     core.info(`Skipping the update of the version file is "${skipVersionFile ? 'enabled' : 'disabled'}"`)
@@ -97,6 +102,13 @@ async function run() {
 
       if (!skipCommit) {
         // Add changed files to git
+        if (preCommit) {
+          await require(preCommit).preCommit({
+            workspace: process.env.GITHUB_WORKSPACE,
+            tag: gitTag,
+            version: versioning.newVersion,
+          })
+        }
         await git.add('.')
         await git.commit(gitCommitMessage.replace('{version}', gitTag))
       }

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,6 @@ async function run() {
         // Add changed files to git
         if (preCommit) {
           await require(preCommit).preCommit({
-            workspace: process.env.GITHUB_WORKSPACE,
             tag: gitTag,
             version: versioning.newVersion,
           })

--- a/test/pre-commit.js
+++ b/test/pre-commit.js
@@ -1,15 +1,19 @@
 const fs = require('fs')
-const path = require('path')
+const t = require('assert')
 
 exports.preCommit = (props) => {
+  const {GITHUB_WORKSPACE} = process.env;
+
+  t.ok(GITHUB_WORKSPACE, 'GITHUB_WORKSPACE should not be empty')
+  t.ok(props.tag, 'tag should not be empty')
+  t.ok(props.version, 'version should not be empty')
+
   const body = {
-    workspace: props.workspace,
+    workspace: GITHUB_WORKSPACE,
     tag: props.tag,
     version: props.version,
     random: Math.random(),
   }
 
-  const dest = path.resolve(props.workspace, 'pre-commit.test.json')
-
-  fs.writeFileSync(dest, JSON.stringify(body, null, 2))
+  fs.writeFileSync('pre-commit.test.json', JSON.stringify(body, null, 2))
 }

--- a/test/pre-commit.js
+++ b/test/pre-commit.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+const path = require('path')
+
+exports.preCommit = (props) => {
+  const body = {
+    workspace: props.workspace,
+    tag: props.tag,
+    version: props.version,
+    random: Math.random(),
+  }
+
+  const dest = path.resolve(props.workspace, 'pre-commit.test.json')
+
+  fs.writeFileSync(dest, JSON.stringify(body, null, 2))
+}


### PR DESCRIPTION
Hey, so I've implemented this feature, I think it might be useful for many. It's useful for me already :)

Let me know what you think and whether it might be landed or not.

Thanks

### About

The idea is to have a way for users to be able to manipulate their repositories
in different ways right before the git-add-git-commit phase. Might be useful in a
lot of different ways: updating arbitrary files that are not directly related to
the package version, but need to have an information about the next version and
being commited before the said version released; or running some chores right
before the commit: including updating docs, dependencies, running scripts, etc.

### Useful example

Here, I am using it to update docker image tag in `action.yml` in my action. [github.com/viktor-ku/pr-commitlint-action/blob/v0.1.2/.github/workflows/release.yml#L34](https://github.com/viktor-ku/pr-commitlint-action/blob/v0.1.2/.github/workflows/release.yml#L34)

### About implementation

I've been thinking whether to run `pre-commit.js` inside of the V8 VM context [nodejs.org/dist/latest-v12.x/docs/api/vm.html](https://nodejs.org/dist/latest-v12.x/docs/api/vm.html), but for simplicity (and for prototypes sake) I choose `require` for now. 