### PR TITLE
fix: fail action on push rejection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,11 @@ async function run() {
       await git.createTag(gitTag)
 
       core.info('Push all changes')
-      await git.push()
+      try{
+        await git.push()
+      }catch (error) {
+        core.setFailed(error.message)
+      }
 
       // Set outputs so other actions (for example actions/create-release) can use it
       core.setOutput('changelog', stringChangelog)


### PR DESCRIPTION
## Issue
The action does not fail when the changes push is rejected. This can be replicated by running the action on a protected branch with a token that does not have the correct permissions. So while the action passes, the CHANGELOG and package.json are never altered. An example can be seen at https://github.com/justin-elias/conventional-commit/runs/912783846?check_suite_focus=true

## Solution
Wrapping the push function in a nested try/catch block resolved the issue. I am not sure why the error is not being caught on the outer try/catch, or if any of the other await functions in that scope are affected as well. 

