### PR TITLE
fix: git initial version

### DIFF
--- a/src/version/git.js
+++ b/src/version/git.js
@@ -13,7 +13,7 @@ module.exports = new (class Git extends BaseVersioning {
       gitSemverTags({
         tagPrefix,
       }, (err, tags) => {
-        const currentVersion = tags.shift().replace(tagPrefix, '')
+        const currentVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : '0.1.0'
 
         // Get the new version
         this.newVersion = bumpVersion(


### PR DESCRIPTION
this should fix #46 

if no tags found it sets `currentVersion` to `0.1.0`