### PR TITLE
fix: Git tags empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           path: "./"
 
+      - run: touch ./test-file-empty.json
+
       - name: Generate changelog
         id: changelog
         uses: ./
@@ -147,6 +149,8 @@ jobs:
         with:
           path: "./"
 
+      - run: touch ./test-file-empty.yaml
+
       - name: Generate changelog
         id: changelog
         uses: ./
@@ -224,6 +228,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: "./"
+
+      - run: touch ./test-file-empty.toml
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,47 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
 
+  test-json-new:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file-new.json'
+
+      - name: Show file
+        id: show
+        run: |
+          echo "$(<test-file-new.json)"
+
+  test-json-empty:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: './test-file-empty.json'
+
+      - run: echo "$(<./test-file-empty.json)"
+
   test-pre-commit:
     runs-on: ubuntu-latest
     steps:
@@ -61,6 +102,25 @@ jobs:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
 
+  test-git-fallback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+      
+      - run: git tag | xargs git tag -d
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          skip-commit: 'true'
+
   test-yaml:
     runs-on: ubuntu-latest
     steps:
@@ -79,6 +139,46 @@ jobs:
           version-file: 'test-file.yaml'
           version-path: 'package.version'
 
+  test-yaml-new:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file-new.yaml'
+          version-path: 'package.version'
+
+      - run: echo "$(<test-file-new.yaml)"
+
+  test-yaml-empty:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: './test-file-empty.yaml'
+          version-path: 'package.version'
+
+      - run: echo "$(<./test-file-empty.yaml)"
+
   test-toml:
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +196,46 @@ jobs:
           github-token: ${{ secrets.github_token }}
           version-file: 'test-file.toml'
           version-path: 'package.version'
+
+  test-toml-new:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file-new.toml'
+          version-path: 'package.version'
+
+      - run: echo "$(<test-file-new.toml)"
+
+  test-toml-empty:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: './test/test-file-empty.toml'
+          version-path: 'package.version'
+
+      - run: echo "$(<./test/test-file-empty.toml)"
 
   test-multiple-files:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
 - **Optional** `skip-commit`: Do create a release commit. Default `'false'`.
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
-- **Optional** `fallback-version`: The fallback version, if none is recognized. Default `'0.1.0'`
+- **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
 
 ### Pre-Commit hook
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
 - **Optional** `skip-commit`: Do create a release commit. Default `'false'`.
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
+- **Optional** `fallback-version`: The fallback version, if none is recognized. Default `'0.1.0'`
 
 ### Pre-Commit hook
 
@@ -164,11 +165,17 @@ $ act -j test-json -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s gith
 # To run / test git versioning
 $ act -j test-git -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
 
+# To run / test git fallback versioning
+$ act -j test-git-fallback -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
+
 # To run / test yaml versioning
 $ act -j test-yaml -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
 
-# To run / toml git versioning
+# To run / test toml versioning
 $ act -j test-toml -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
+
+# To run / test empty / new files test
+$ act -j test-[json/toml/yaml]-[empty/new] -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
 
 # To run pre-commit test
 $ act -j test-pre-commit -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ inputs:
     required: false
 
   fallback-version:
-    description: 'The fallback version, if none is recognized'
+    description: 'The fallback version, if no older one can be detected, or if it is the first one'
     default: '0.1.0'
     required: false
 

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,11 @@ inputs:
     description: 'Path to the pre-commit script file'
     required: false
 
+  fallback-version:
+    description: 'The fallback version, if none is recognized'
+    default: '0.1.0'
+    required: false
+
 
 outputs:
   changelog:

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,6 +372,11 @@
         "find-up": "^4.0.0"
       }
     },
+    "@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -2237,11 +2242,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
       }
-    },
-    "toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "trim-newlines": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "dependencies": {
     "@actions/core": "1.2.4",
     "@actions/exec": "1.0.4",
+    "@iarna/toml": "^2.2.5",
     "conventional-changelog": "3.1.21",
     "conventional-recommended-bump": "6.0.9",
     "git-semver-tags": "4.0.0",
     "object-path": "^0.11.4",
-    "toml": "^3.0.0",
     "yaml": "^1.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "conventional-recommended-bump": "6.0.9",
     "git-semver-tags": "4.0.0",
     "object-path": "^0.11.4",
+    "semver": "^6.0.0",
     "yaml": "^1.10.0"
   },
   "devDependencies": {

--- a/src/helpers/bumpVersion.js
+++ b/src/helpers/bumpVersion.js
@@ -42,5 +42,7 @@ module.exports = (releaseType, version) => {
     }
   }
 
+  core.info(`The version could not be detected, the new version is '${major}.${minor}.${patch}'.`)
+
   return `${major}.${minor}.${patch}`
 }

--- a/src/helpers/bumpVersion.js
+++ b/src/helpers/bumpVersion.js
@@ -1,3 +1,6 @@
+const core = require('@actions/core')
+const semverValid = require('semver').valid
+
 /**
  * Bumps the given version with the given release type
  *
@@ -6,22 +9,37 @@
  * @returns {string}
  */
 module.exports = (releaseType, version) => {
-  let [major, minor, patch] = version.split('.')
+  let major, minor, patch
 
-  switch (releaseType) {
-    case 'major':
-      major = parseInt(major, 10) + 1
-      minor = 0
+  if (version) {
+    [major, minor, patch] = version.split('.')
+
+    switch (releaseType) {
+      case 'major':
+        major = parseInt(major, 10) + 1
+        minor = 0
+        patch = 0
+        break
+
+      case 'minor':
+        minor = parseInt(minor, 10) + 1
+        patch = 0
+        break
+
+      default:
+        patch = parseInt(patch, 10) + 1
+    }
+  } else {
+    let version = semverValid(core.getInput('fallback-version'))
+
+    if (version) {
+      [major, minor, patch] = version.split('.')
+    } else {
+      // default
+      major = 0
+      minor = 1
       patch = 0
-      break
-
-    case 'minor':
-      minor = parseInt(minor, 10) + 1
-      patch = 0
-      break
-
-    default:
-      patch = parseInt(patch, 10) + 1
+    }
   }
 
   return `${major}.${minor}.${patch}`

--- a/src/helpers/bumpVersion.js
+++ b/src/helpers/bumpVersion.js
@@ -40,9 +40,9 @@ module.exports = (releaseType, version) => {
       minor = 1
       patch = 0
     }
-  }
 
-  core.info(`The version could not be detected, the new version is '${major}.${minor}.${patch}'.`)
+    core.info(`The version could not be detected, using fallback version '${major}.${minor}.${patch}'.`)
+  }
 
   return `${major}.${minor}.${patch}`
 }

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -97,7 +97,7 @@ module.exports = new (class Git {
    * @return {Promise<>}
    */
   pull = () => (
-    this.exec(`pull --unshallow ${core.getInput('git-pull-method')}`)
+    this.exec(`pull ${core.getInput('git-pull-method')}`)
   )
 
   /**

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -97,7 +97,7 @@ module.exports = new (class Git {
    * @return {Promise<>}
    */
   pull = () => (
-    this.exec(`pull ${core.getInput('git-pull-method')}`)
+    this.exec(`pull --unshallow ${core.getInput('git-pull-method')}`)
   )
 
   /**

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -97,7 +97,7 @@ module.exports = new (class Git {
    * @return {Promise<>}
    */
   pull = () => (
-    this.exec(`pull --unshallow ${core.getInput('git-pull-method')}`)
+    this.exec(`pull --unshallow --tags ${core.getInput('git-pull-method')}`)
   )
 
   /**

--- a/src/version/base.js
+++ b/src/version/base.js
@@ -25,9 +25,7 @@ module.exports = class BaseVersioning {
    * @return {string}
    */
   read = () => {
-    if (fs.existsSync(this.fileLocation)) {
-      return fs.readFileSync(this.fileLocation, 'utf8')
-    }
+    return fs.existsSync(this.fileLocation) ? fs.readFileSync(this.fileLocation, 'utf8') : ''
   }
 
   /**

--- a/src/version/base.js
+++ b/src/version/base.js
@@ -25,7 +25,9 @@ module.exports = class BaseVersioning {
    * @return {string}
    */
   read = () => {
-    return fs.readFileSync(this.fileLocation, 'utf8')
+    if (fs.existsSync(this.fileLocation)) {
+      return fs.readFileSync(this.fileLocation, 'utf8')
+    }
   }
 
   /**

--- a/src/version/git.js
+++ b/src/version/git.js
@@ -13,7 +13,7 @@ module.exports = new (class Git extends BaseVersioning {
       gitSemverTags({
         tagPrefix,
       }, (err, tags) => {
-        const currentVersion = tags.shift().replace(tagPrefix, '')
+        const currentVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : null
 
         // Get the new version
         this.newVersion = bumpVersion(

--- a/src/version/git.js
+++ b/src/version/git.js
@@ -13,7 +13,7 @@ module.exports = new (class Git extends BaseVersioning {
       gitSemverTags({
         tagPrefix,
       }, (err, tags) => {
-        const currentVersion = tags.shift().replace(tagPrefix, '')
+        const currentVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : '0.1.0'
 
         // Get the new version
         this.newVersion = bumpVersion(

--- a/src/version/git.js
+++ b/src/version/git.js
@@ -13,7 +13,7 @@ module.exports = new (class Git extends BaseVersioning {
       gitSemverTags({
         tagPrefix,
       }, (err, tags) => {
-        const currentVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : '0.1.0'
+        const currentVersion = tags.shift().replace(tagPrefix, '')
 
         // Get the new version
         this.newVersion = bumpVersion(

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core')
 const objectPath = require('object-path')
 
 const BaseVersioning = require('./base')
@@ -14,7 +15,21 @@ module.exports = new (class Json extends BaseVersioning {
   bump = (releaseType) => {
     // Read the file
     const fileContent = this.read()
-    const jsonContent = JSON.parse(fileContent)
+
+    // Parse the file
+    let jsonContent
+    try {
+      jsonContent = JSON.parse(fileContent)
+    } catch (error) {
+      core.startGroup(`Error when parsing the file '${this.fileLocation}'`)
+      core.info(`File-Content: ${fileContent}`)
+      core.info(error) // should be 'warning' ?
+      core.endGroup()
+
+      jsonContent = {}
+    }
+
+    // Get the old version
     const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
 
     // Get the new version

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -12,15 +12,10 @@ module.exports = new (class Json extends BaseVersioning {
    * @return {*}
    */
   bump = (releaseType) => {
-    let jsonContent = {}
-    let oldVersion
-
     // Read the file
     const fileContent = this.read()
-    if (fileContent) {
-      jsonContent = JSON.parse(fileContent)
-      oldVersion = objectPath.get(jsonContent, this.versionPath)
-    }
+    const jsonContent = JSON.parse(fileContent)
+    const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = bumpVersion(

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -12,10 +12,15 @@ module.exports = new (class Json extends BaseVersioning {
    * @return {*}
    */
   bump = (releaseType) => {
+    let jsonContent = {}
+    let oldVersion
+
     // Read the file
     const fileContent = this.read()
-    const jsonContent = JSON.parse(fileContent)
-    const oldVersion = objectPath.get(jsonContent, this.versionPath)
+    if (fileContent) {
+      jsonContent = JSON.parse(fileContent)
+      oldVersion = objectPath.get(jsonContent, this.versionPath)
+    }
 
     // Get the new version
     this.newVersion = bumpVersion(

--- a/src/version/toml.js
+++ b/src/version/toml.js
@@ -13,15 +13,10 @@ module.exports = new (class Toml extends BaseVersioning{
    * @return {*}
    */
   bump = (releaseType) => {
-    let tomlContent = {}
-    let oldVersion
-
     // Read the file
     const fileContent = this.read()
-    if (fileContent) {
-      tomlContent = toml.parse(fileContent)
-      oldVersion = objectPath.get(tomlContent, this.versionPath)
-    }
+    const tomlContent = toml.parse(fileContent)
+    const oldVersion = objectPath.get(tomlContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = bumpVersion(
@@ -29,11 +24,11 @@ module.exports = new (class Toml extends BaseVersioning{
       oldVersion,
     )
 
-    // Get the name of where the version is in
-    const versionName = this.versionPath.split('.').pop()
-
     // Update the file
-    if (fileContent) {
+    if (oldVersion) {
+      // Get the name of where the version is in
+      const versionName = this.versionPath.split('.').pop()
+
       this.update(
         // We use replace instead of yaml.stringify so we can preserve white spaces and comments
         fileContent.replace(

--- a/src/version/yaml.js
+++ b/src/version/yaml.js
@@ -13,10 +13,15 @@ module.exports = new (class Yaml extends BaseVersioning{
    * @return {*}
    */
   bump = (releaseType) => {
+    let yamlContent = {}
+    let oldVersion
+
     // Read the file
     const fileContent = this.read()
-    const yamlContent = yaml.parse(fileContent)
-    const oldVersion = objectPath.get(yamlContent, this.versionPath)
+    if (fileContent) {
+      yamlContent = yaml.parse(fileContent)
+      oldVersion = objectPath.get(yamlContent, this.versionPath)
+    }
 
     // Get the new version
     this.newVersion = bumpVersion(
@@ -28,13 +33,19 @@ module.exports = new (class Yaml extends BaseVersioning{
     const versionName = this.versionPath.split('.').pop()
 
     // Update the file
-    this.update(
-      // We use replace instead of yaml.stringify so we can preserve white spaces and comments
-      fileContent.replace(
-        `${versionName}: '${oldVersion}'`,
-        `${versionName}: '${this.newVersion}'`,
-      ),
-    )
+    if (fileContent) {
+      this.update(
+        // We use replace instead of yaml.stringify so we can preserve white spaces and comments
+        fileContent.replace(
+          `${versionName}: '${oldVersion}'`,
+          `${versionName}: '${this.newVersion}'`,
+        ),
+      )
+    } else {
+      // Update the content with the new version
+      objectPath.set(yamlContent, this.versionPath, this.newVersion)
+      this.update(yaml.stringify(yamlContent))
+    }
   }
 
 })

--- a/src/version/yaml.js
+++ b/src/version/yaml.js
@@ -13,15 +13,10 @@ module.exports = new (class Yaml extends BaseVersioning{
    * @return {*}
    */
   bump = (releaseType) => {
-    let yamlContent = {}
-    let oldVersion
-
     // Read the file
     const fileContent = this.read()
-    if (fileContent) {
-      yamlContent = yaml.parse(fileContent)
-      oldVersion = objectPath.get(yamlContent, this.versionPath)
-    }
+    const yamlContent = yaml.parse(fileContent) || {}
+    const oldVersion = objectPath.get(yamlContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = bumpVersion(
@@ -29,11 +24,11 @@ module.exports = new (class Yaml extends BaseVersioning{
       oldVersion,
     )
 
-    // Get the name of where the version is in
-    const versionName = this.versionPath.split('.').pop()
-
     // Update the file
-    if (fileContent) {
+    if (oldVersion) {
+      // Get the name of where the version is in
+      const versionName = this.versionPath.split('.').pop()
+
       this.update(
         // We use replace instead of yaml.stringify so we can preserve white spaces and comments
         fileContent.replace(


### PR DESCRIPTION
if `skipVersionFile` or `skipCommit` is set, then `checkout` must be used `with: fetch-depth: 0`

```yaml
- uses: actions/checkout@v2
  with:
    fetch-depth: 0
- name: Conventional Changelog Action
  uses: TriPSs/conventional-changelog-action@v3
  with:
    skip-version-file: 'true'
    skip-commit: 'true'
```