### PR TITLE
feat: Allow to specify a config file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,3 +259,24 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           version-file: 'package.json, package-lock.json'
+
+  test-config-file-path:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - name: Install Packages
+        run: yarn
+
+      - name: Generate Changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+        with:
+          github-token: ${{ secrets.github_token }}
+          skip-version-file: 'true'
+          config-file-path: './test-changelog.config.js'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `skip-commit`: Do create a release commit. Default `'false'`.
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
 - **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
+- **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
 
 ### Pre-Commit hook
 
@@ -50,6 +51,23 @@ export function preCommit(props: Props): void {}
 ```
 
 A bunch of useful environment variables are available to the script with `process.env`. See [docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables) to learn more.
+
+### Config-File-Path
+A config file to define the conventional commit settings. Use it if you need to override values like `issuePrefix` or `issueUrlFormat`. If you set a `config-file-path`, the `preset` setting will be ignored. Therefore use an existing config and override the values you want to adjust.
+
+example:  
+```javascript
+'use strict'
+const config = require('conventional-changelog-conventionalcommits');
+
+module.exports = config({
+    "issuePrefixes": ["TN-"],
+    "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}"
+})
+```
+The specified path can be relative or absolute. If it is relative, then it will be based on the `GITHUB_WORKSPACE` path.
+
+Make sure to install all required packages in the workflow before executing this action.
 
 ## Outputs
 
@@ -185,6 +203,9 @@ $ act -j test-pre-commit -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -
 
 # To run / multiple files test
 $ act -j multiple-files -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
+
+# To run / config file path test
+$ act -j test-config-file-path -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -s github_token=fake-token
 ```
 
 ## [License](./LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,9 @@ inputs:
   fallback-version:
     description: 'The fallback version, if no older one can be detected, or if it is the first one'
     default: '0.1.0'
+    
+  config-file-path:
+    description: 'Path to the conventional changelog config file. If set, the preset setting will be ignored'
     required: false
 
 

--- a/src/helpers/generateChangelog.js
+++ b/src/helpers/generateChangelog.js
@@ -10,15 +10,19 @@ const conventionalChangelog = require('conventional-changelog')
  * @param releaseCount
  * @returns {*}
  */
-const getChangelogStream = (tagPrefix, preset, version, releaseCount) => conventionalChangelog({
-    preset,
-    releaseCount: parseInt(releaseCount, 10),
-    tagPrefix,
-  },
+const getChangelogStream = (tagPrefix, preset, version, releaseCount, config) => conventionalChangelog({
+  preset,
+  releaseCount: parseInt(releaseCount, 10),
+  tagPrefix,
+  config
+},
   {
     version,
     currentTag: `${tagPrefix}${version}`,
   },
+  {},
+  config && config.parserOpts,
+  config && config.writerOpts
 )
 
 module.exports = getChangelogStream
@@ -32,8 +36,8 @@ module.exports = getChangelogStream
  * @param releaseCount
  * @returns {Promise<string>}
  */
-module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount) => new Promise((resolve, reject) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount)
+module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, config) => new Promise((resolve, reject) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config)
 
   let changelog = ''
 
@@ -54,8 +58,8 @@ module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCou
  * @param releaseCount
  * @returns {Promise<>}
  */
-module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount) => new Promise((resolve) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount)
+module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, config) => new Promise((resolve) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config)
 
   changelogStream
     .pipe(fs.createWriteStream(fileName))

--- a/test-changelog.config.js
+++ b/test-changelog.config.js
@@ -1,0 +1,9 @@
+'use strict'
+const config = require('conventional-changelog-conventionalcommits');
+
+module.exports = config({
+    "types": [
+        { type: 'feat', section: 'New Features' },
+        { type: 'fix', section: 'Bugs' }
+    ]
+})


### PR DESCRIPTION
Hi,

we need to adjust the preset to specify things like the `issuePrefix`. Therefore I've added support to specify a path to a config file to set those values.

example:

```
'use strict'
const config = require('conventional-changelog-conventionalcommits');

module.exports = config({
    "issuePrefixes": ["TN-"],
    "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}",
    "types": [
        { type: 'feat', section: 'Features' },
        { type: 'fix', section: 'Bug Fixes' },
        { type: 'perf', section: 'Performance' },
        { type: 'revert', section: 'Reverts' },
        { type: 'build', section: 'Build System' },
        { type: 'ci', section: 'Continuous Integration' },
        { type: 'refactor', section: 'Code Refactoring' },
        { type: 'docs', section: 'Documentation', hidden: true },
        { type: 'style', section: 'Styles', hidden: true },
        { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
        { type: 'test', section: 'Tests', hidden: true },
    ]
})
```

The path can be relative to your workspace root, meaning `./changelog.config.js` is expected to be in the root of your repository.

If a config like above is used, the user needs to make sure that all required packages are installed when running the github action.

p.s.
To test this feature use my release: janro1/conventional-changelog-action@v3.3.0