### PR TITLE
Added new input 'version-file-type' to specify how to handle the version-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `output-file`: File to output the changelog to. Default `CHANGELOG.md`, when providing `'false'` no file will be generated / updated.
 - **Optional** `release-count`: Number of releases to preserve in changelog. Default `5`, use `0` to regenerate all.
 - **Optional** `version-file`: The path to the file that contains the version to bump. Default `./package.json`.
+- **Optional** `version-file-type`: The file type, in case the extension doesn't match the file content. If not provided, infers from extension.
 - **Optional** `version-path`: The place inside the version file to bump. Default `version`.
 - **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occured when you push `chore` commit with `angular` for example. Default `'true'`.
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
@@ -102,7 +103,8 @@ Overwrite everything
     tag-prefix: 'v'
     output-file: 'MY_CUSTOM_CHANGELOG.md'
     release-count: '10'
-    version-file: './my_custom_version_file.json' // or .yml, .yaml, .toml
+    version-file: './my_custom_version_file.custom_extension' // or .json, .yml, .yaml, .toml
+    version-file-type: 'json' // or yml, yaml, toml
     version-path: 'path.to.version'
     skip-on-empty: 'false'
     skip-version-file: 'false'

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     default: './package.json'
     required: false
 
+  version-file-type:
+    description: 'Specify an extension to handle version-file in case it has a custom extension'
+    required: false
+
   version-path:
     description: 'The place inside the version file to bump'
     default: 'version'

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ async function run() {
     const outputFile = core.getInput('output-file')
     const releaseCount = core.getInput('release-count')
     const versionFile = core.getInput('version-file')
+    const versionFileType = core.getInput('version-file-type')
     const versionPath = core.getInput('version-path')
     const skipVersionFile = core.getInput('skip-version-file').toLowerCase() === 'true'
     const skipCommit = core.getInput('skip-commit').toLowerCase() === 'true'
@@ -46,6 +47,7 @@ async function run() {
     core.info(`Using "${gitUserEmail}" as git user.email`)
     core.info(`Using "${releaseCount}" release count`)
     core.info(`Using "${versionFile}" as version file`)
+    core.info(`Using "${versionFileType}" as version file type`)
     core.info(`Using "${versionPath}" as version path`)
     core.info(`Using "${tagPrefix}" as tag prefix`)
     core.info(`Using "${outputFile}" as output file`)
@@ -91,9 +93,13 @@ async function run() {
         core.info(`Files to bump: ${files.join(', ')}`)
 
         const versioning = await Promise.all(files.map((file) => {
-          const fileExtension = file.split('.').pop()
-          core.info(`Bumping version to file "${file}" with extension "${fileExtension}"`)
-          return handleVersioningByExtension(fileExtension, file, versionPath, recommendation.releaseType)
+
+          var extension = versionFileType
+          if(versionFileType == null){
+            extension = file.split('.').pop()
+          }
+          core.info(`Bumping version to file "${file}" with extension "${extension}"`)
+          return handleVersioningByExtension(extension, file, versionPath, recommendation.releaseType)
         }));
 
         newVersion = versioning[0].newVersion

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ async function run() {
         const versioning = await Promise.all(files.map((file) => {
 
           var extension = versionFileType
-          if(versionFileType == null){
+          if(versionFileType === null){
             extension = file.split('.').pop()
           }
           core.info(`Bumping version to file "${file}" with extension "${extension}"`)


### PR DESCRIPTION
Some tools like Unity have YML files under the .asset extension. I added a new input to specify an extension to indicate how to process the file.

For example I can set 
`version-file: ProjectSettings.asset
version-file-type: yml`
so that the version bump is done as if the file was .yml

If this new input is not specified, then it works as always, by parsing the file extension to decide how to process the file.