### PR TITLE
fix: Add pre-changelog-generation input in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
 - **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
 - **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
+- **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
 
 ### Pre-Commit hook
 


### PR DESCRIPTION
Forgot to add new input option in README