### PR TITLE
fix: Bump version with one provided in pre-changelog-generation hook

### DIFF
--- a/src/version/base.js
+++ b/src/version/base.js
@@ -32,9 +32,10 @@ module.exports = class BaseVersioning {
    * Logic for bumping the version
    *
    * @param {!string} releaseType - The type of release
+   * @param {string} customVersion - Bump file with manually provided version
    * @return {*}
    */
-  bump = (releaseType) => {
+  bump = (releaseType, customVersion) => {
     throw new Error('Implement bump logic in class!')
   }
 

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -10,9 +10,10 @@ module.exports = new (class Json extends BaseVersioning {
    * Bumps the version in the package.json
    *
    * @param {!string} releaseType - The type of release
+   * @param {string} customVersion - Bump file with manually provided version
    * @return {*}
    */
-  bump = (releaseType) => {
+  bump = (releaseType, customVersion) => {
     // Read the file
     const fileContent = this.read()
 
@@ -37,6 +38,10 @@ module.exports = new (class Json extends BaseVersioning {
       releaseType,
       oldVersion,
     )
+
+    if (customVersion) {
+      this.newVersion = customVersion 
+    }
 
     // Update the content with the new version
     objectPath.set(jsonContent, this.versionPath, this.newVersion)

--- a/src/version/toml.js
+++ b/src/version/toml.js
@@ -10,9 +10,10 @@ module.exports = new (class Toml extends BaseVersioning{
    * Bumps the version in the package.json
    *
    * @param {!string} releaseType - The type of release
+   * @param {string} customVersion - Bump file with manually provided version
    * @return {*}
    */
-  bump = (releaseType) => {
+  bump = (releaseType, customVersion) => {
     // Read the file
     const fileContent = this.read()
     const tomlContent = toml.parse(fileContent)
@@ -23,6 +24,10 @@ module.exports = new (class Toml extends BaseVersioning{
       releaseType,
       oldVersion,
     )
+
+    if (customVersion) {
+      this.newVersion = customVersion 
+    }
 
     // Update the file
     if (oldVersion) {

--- a/src/version/yaml.js
+++ b/src/version/yaml.js
@@ -10,9 +10,10 @@ module.exports = new (class Yaml extends BaseVersioning{
    * Bumps the version in the package.json
    *
    * @param {!string} releaseType - The type of release
+   * @param {string} customVersion - Bump file with manually provided version
    * @return {*}
    */
-  bump = (releaseType) => {
+  bump = (releaseType, customVersion) => {
     // Read the file
     const fileContent = this.read()
     const yamlContent = yaml.parse(fileContent) || {}
@@ -23,6 +24,10 @@ module.exports = new (class Yaml extends BaseVersioning{
       releaseType,
       oldVersion,
     )
+
+    if (customVersion) {
+      this.newVersion = customVersion 
+    }
 
     // Update the file
     if (oldVersion) {


### PR DESCRIPTION
I totally forgot about bumping version in the corresponding file. I should have tested it more thoroughly beforehand =\