### PR TITLE
feat: add [skip ci] by default to commit message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -620,3 +620,42 @@ jobs:
           else
             echo "Changelog config not applied" && exit 1
           fi
+
+
+  test-skip-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit --allow-empty -m 'feat: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v1.5.0'
+          SKIP_CI: 'false'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file.json'
+          skip-ci: 'false'
+
+      - name: Show file
+        run: |
+          echo "$(<test-file.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file.json'
+          EXPECTED_VERSION: '1.5.0'
+
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
 - **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
 - **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
+- **Optional** `skip-ci`: Adds instruction to github to not consider the push something to rebuild. Default `true`.
 
 ### Pre-Commit hook
 

--- a/action.yml
+++ b/action.yml
@@ -108,6 +108,10 @@ inputs:
     description: 'Path to the pre-changelog-generation script file'
     required: false
 
+  skip-ci:
+    description: 'Adds [skip ci] to commit message, to avoid triggering a new build'
+    default: 'true'
+    required: false
 
 outputs:
   changelog:

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -161,7 +161,7 @@ module.exports = new (class Git {
    */
   testHistory = () => {
     if (ENV === 'dont-use-git') {
-      const { EXPECTED_TAG, SKIPPED_COMMIT, EXPECTED_NO_PUSH, SKIPPED_PULL } = process.env
+      const { EXPECTED_TAG, SKIPPED_COMMIT, EXPECTED_NO_PUSH, SKIPPED_PULL, SKIP_CI } = process.env
 
       const expectedCommands = [
         'git config user.name "Conventional Changelog Action"',
@@ -174,7 +174,11 @@ module.exports = new (class Git {
 
       if (!SKIPPED_COMMIT) {
         expectedCommands.push('git add .')
-        expectedCommands.push(`git commit -m "chore(release): ${EXPECTED_TAG}"`)
+        if (SKIP_CI === false) {
+          expectedCommands.push(`git commit -m "chore(release): ${EXPECTED_TAG}"`)
+        } else {
+          expectedCommands.push(`git commit -m "chore(release): ${EXPECTED_TAG} [skip ci]"`)
+        }
       }
 
       expectedCommands.push(`git tag -a ${EXPECTED_TAG} -m "${EXPECTED_TAG}"`)

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ async function handleVersioningByExtension(ext, file, versionPath, releaseType) 
 
 async function run() {
   try {
-    const gitCommitMessage = core.getInput('git-message')
+    let gitCommitMessage = core.getInput('git-message')
     const gitUserName = core.getInput('git-user-name')
     const gitUserEmail = core.getInput('git-user-email')
     const gitPush = core.getInput('git-push').toLowerCase() === 'true'
@@ -42,6 +42,11 @@ async function run() {
     const skipEmptyRelease = core.getInput('skip-on-empty').toLowerCase() === 'true'
     const conventionalConfigFile = core.getInput('config-file-path')
     const preChangelogGenerationFile = core.getInput('pre-changelog-generation')
+    const skipCi = core.getInput('skip-ci')
+
+    if (skipCi) {
+      gitCommitMessage += " [skip ci]"
+    }
 
     core.info(`Using "${preset}" preset`)
     core.info(`Using "${gitCommitMessage}" as commit message`)


### PR DESCRIPTION
This is useful when you are working on an organizational
repository where you are passing in a custom admin token
as any pushes with this token, will cause a new build to be
scheduled.

This adds the [skip ci] instruction by default.
With an option to supress it