### PR TITLE
feat: Add `git-path` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `git-pull-method`: The git pull method used when pulling all changes from remote. Default `--ff-only`
 - **Optional** `git-push`: Push all the GIT changes. Default `true`
 - **Optional** `git-branch`: The branch used to push. Default is the current branch (`${{ github.ref }}`)
+- **Optional** `git-url`: Git repository domain. Default is `github.com`
+- **Optional** `git-path`: Path filter for the logs. If set, only commits that match the path filter will be considered. By default, we won't use this feature(empty string).
 - **Optional** `preset`: Preset that is used from conventional commits. Default `angular`.
 - **Optional** `tag-prefix`: Prefix for the git tags. Default `v`.
 - **Optional** `output-file`: File to output the changelog to. Default `CHANGELOG.md`, when providing `'false'` no file will be generated / updated.
@@ -18,7 +20,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `version-file`: The path to the file that contains the version to bump. Default `./package.json`.
 - **Optional** `version-path`: The place inside the version file to bump. Default `version`.
 - **Optional** `skip-git-pull`: Do not pull the repo before tagging. Ensure you full cloned the repo in the first place to get tags. Default `'false'`.
-- **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occured when you push `chore` commit with `angular` for example. Default `'true'`.
+- **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occurred when you push `chore` commit with `angular` for example. Default `'true'`.
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
 - **Optional** `skip-commit`: Do not create a release commit. Default `'false'`.
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.

--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,11 @@ inputs:
     default: 'github.com'
     required: false
 
+  git-path:
+    description: 'Path filter for the logs. If set, only commits that match the path filter will be considered'
+    default: ''
+    required: false
+
   skip-ci:
     description: 'Adds [skip ci] to commit message, to avoid triggering a new build'
     default: 'true'

--- a/src/helpers/generateChangelog.js
+++ b/src/helpers/generateChangelog.js
@@ -8,9 +8,11 @@ const conventionalChangelog = require('conventional-changelog')
  * @param preset
  * @param version
  * @param releaseCount
+ * @param config
+ * @param gitPath
  * @returns {*}
  */
-const getChangelogStream = (tagPrefix, preset, version, releaseCount, config) => conventionalChangelog({
+const getChangelogStream = (tagPrefix, preset, version, releaseCount, config, gitPath) => conventionalChangelog({
     preset,
     releaseCount: parseInt(releaseCount, 10),
     tagPrefix,
@@ -20,7 +22,9 @@ const getChangelogStream = (tagPrefix, preset, version, releaseCount, config) =>
     version,
     currentTag: `${tagPrefix}${version}`,
   },
-  {},
+  {
+    path: gitPath === '' || gitPath === null ? undefined : gitPath
+  },
   config && config.parserOpts,
   config && config.writerOpts
 )
@@ -34,10 +38,12 @@ module.exports = getChangelogStream
  * @param preset
  * @param version
  * @param releaseCount
+ * @param config
+ * @param gitPath
  * @returns {Promise<string>}
  */
-module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, config) => new Promise((resolve, reject) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config)
+module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, config, gitPath) => new Promise((resolve, reject) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config, gitPath)
 
   let changelog = ''
 
@@ -56,10 +62,12 @@ module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCou
  * @param version
  * @param fileName
  * @param releaseCount
+ * @param config
+ * @param gitPath
  * @returns {Promise<>}
  */
-module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, config) => new Promise((resolve) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config)
+module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, config, gitPath) => new Promise((resolve) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config, gitPath)
 
   changelogStream
     .pipe(fs.createWriteStream(fileName))

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ async function run() {
     const conventionalConfigFile = core.getInput('config-file-path')
     const preChangelogGenerationFile = core.getInput('pre-changelog-generation')
     const gitUrl = core.getInput('git-url')
+    const gitPath = core.getInput('git-path')
     const skipCi = core.getBooleanInput('skip-ci')
     const createSummary = core.getBooleanInput('create-summary')
 
@@ -63,6 +64,7 @@ async function run() {
     core.info(`Using "${conventionalConfigFile}" as config file`)
     core.info(`Using "${gitUrl}" as gitUrl`)
     core.info(`Using "${gitBranch}" as gitBranch`)
+    core.info(`Using "${gitPath}" as gitPath`)
 
     if (preCommitFile) {
       core.info(`Using "${preCommitFile}" as pre-commit script`)
@@ -144,7 +146,7 @@ async function run() {
       }
 
       // Generate the string changelog
-      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, newVersion, 1, config)
+      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, newVersion, 1, config, gitPath)
       core.info('Changelog generated')
       core.info(stringChangelog)
 
@@ -162,7 +164,7 @@ async function run() {
       // If output file === 'false' we don't write it to file
       if (outputFile !== 'false') {
         // Generate the changelog
-        await changelog.generateFileChangelog(tagPrefix, preset, newVersion, outputFile, releaseCount, config)
+        await changelog.generateFileChangelog(tagPrefix, preset, newVersion, outputFile, releaseCount, config, gitPath)
       }
 
       if (!skipCommit) {


### PR DESCRIPTION
`git-path` acts as a path filter for the logs. If set, only commits that match the path filter will be considered. By default, we won't use this feature(empty string).

closes #178