### PR TITLE
feat: Add pre-release support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -728,3 +728,38 @@ jobs:
         env:
           FILES: 'test-file.json'
           EXPECTED_VERSION: '1.4.6-alpha.0'
+
+  test-pre-release-to-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit --allow-empty -m 'feat: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v1.5.0'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file-pre-release.json'
+          pre-release: false # This is the default value, but we want to be explicit
+
+      - name: Show file
+        run: |
+          echo "$(<test-file-pre-release.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file-pre-release.json'
+          EXPECTED_VERSION: '1.5.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -658,4 +658,73 @@ jobs:
           FILES: 'test-file.json'
           EXPECTED_VERSION: '1.5.0'
 
+  test-pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
 
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit --allow-empty -m 'feat: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v1.4.6-rc.0'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file.json'
+          pre-release: true
+
+      - name: Show file
+        run: |
+          echo "$(<test-file.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file.json'
+          EXPECTED_VERSION: '1.4.6-rc.0'
+
+  test-pre-release-identifier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit --allow-empty -m 'feat: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v1.4.6-alpha.0'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file.json'
+          pre-release: true
+          pre-release-identifier: 'alpha'
+
+      - name: Show file
+        run: |
+          echo "$(<test-file.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file.json'
+          EXPECTED_VERSION: '1.4.6-alpha.0'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
 - **Optional** `skip-ci`: Adds instruction to Github to not consider the push something to rebuild. Default `true`.
 - **Optional** `create-summary`: Adds the generated changelog as Action Summary. Default `false`.
+- **Optional** `pre-release`: Marks the release as pre-release. Default `false`.
+- **Optional** `pre-release-identifier`: The identifier to use for the pre-release. Default `rc`.
 
 ### Pre-Commit hook
 

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
   git-branch:
     description: 'The git branch to be pushed'
     default: ${{ github.ref }}
-    required: false    
+    required: false
 
   preset:
     description: 'The preset from Conventional Changelog to use'
@@ -80,7 +80,7 @@ inputs:
     description: 'Do not pull the repo before tagging. Ensure you full cloned the repo in the first place to get tags'
     default: 'false'
     required: false
-  
+
   skip-on-empty:
     description: 'Do nothing when the changelog from the latest release is empty'
     default: 'true'
@@ -131,6 +131,16 @@ inputs:
   create-summary:
     description: 'Adds the generated changelog as Action Summary'
     default: 'false'
+    required: false
+
+  pre-release:
+    description: 'Marks the release as pre-release'
+    default: 'false'
+    required: false
+
+  pre-release-identifier:
+    description: 'The identifier to use for pre-releases'
+    default: 'rc'
     required: false
 
 outputs:

--- a/src/helpers/generateChangelog.js
+++ b/src/helpers/generateChangelog.js
@@ -10,13 +10,15 @@ const conventionalChangelog = require('conventional-changelog')
  * @param releaseCount
  * @param config
  * @param gitPath
+ * @param skipUnstable
  * @returns {*}
  */
-const getChangelogStream = (tagPrefix, preset, version, releaseCount, config, gitPath) => conventionalChangelog({
+const getChangelogStream = (tagPrefix, preset, version, releaseCount, config, gitPath, skipUnstable) => conventionalChangelog({
     preset,
     releaseCount: parseInt(releaseCount, 10),
     tagPrefix,
-    config
+    config,
+    skipUnstable
   },
   {
     version,
@@ -40,10 +42,11 @@ module.exports = getChangelogStream
  * @param releaseCount
  * @param config
  * @param gitPath
+ * @param skipUnstable
  * @returns {Promise<string>}
  */
-module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, config, gitPath) => new Promise((resolve, reject) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config, gitPath)
+module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, config, gitPath, skipUnstable) => new Promise((resolve, reject) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config, gitPath, skipUnstable)
 
   let changelog = ''
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ async function run() {
     const gitPath = core.getInput('git-path')
     const skipCi = core.getBooleanInput('skip-ci')
     const createSummary = core.getBooleanInput('create-summary')
+    const prerelease = core.getBooleanInput('pre-release')
 
     if (skipCi) {
       gitCommitMessage += ' [skip ci]'
@@ -84,7 +85,7 @@ async function run() {
 
     const config = conventionalConfigFile && requireScript(conventionalConfigFile)
 
-    conventionalRecommendedBump({ preset, tagPrefix, config }, async (error, recommendation) => {
+    conventionalRecommendedBump({ preset, tagPrefix, config, skipUnstable: !prerelease }, async (error, recommendation) => {
       if (error) {
         core.setFailed(error.message)
         return
@@ -146,7 +147,7 @@ async function run() {
       }
 
       // Generate the string changelog
-      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, newVersion, 1, config, gitPath)
+      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, newVersion, 1, config, gitPath, !prerelease)
       core.info('Changelog generated')
       core.info(stringChangelog)
 

--- a/src/version/git.js
+++ b/src/version/git.js
@@ -9,8 +9,9 @@ module.exports = class Git extends BaseVersioning {
   bump = (releaseType) => {
     return new Promise((resolve) => {
       const tagPrefix = core.getInput('tag-prefix')
+      const prerelease = core.getBooleanInput('pre-release')
 
-      gitSemverTags({ tagPrefix, }, async (err, tags) => {
+      gitSemverTags({ tagPrefix, skipUnstable: !prerelease }, async (err, tags) => {
         const currentVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : null
 
         // Get the new version

--- a/test-file-pre-release.json
+++ b/test-file-pre-release.json
@@ -1,0 +1,4 @@
+{
+  "name": "Test JSON",
+  "version": "1.4.6-alpha.0"
+}


### PR DESCRIPTION
# Changes
Added `pre-release` and `pre-release-identifier` options.
- `pre-release`: Marks the release as pre-release. Default `false`.
- `pre-release-identifier`: The identifier to use for the pre-release. Default `rc`.

# Examples
```
pre-release: true
pre-release-identifier: beta
```
Current version: v1.10.5
Bumped version: v1.10.6-beta.0

Current version: v1.10.6-beta.0
Bumped version: v1.10.6-beta.1

Current version: v1.10.6-beta.1
Bumped version: v1.10.6-beta.2

```
pre-release: false // default
```

Current version: v1.10.6-beta.2
Bumped version: v1.10.6
# Fixes
fixes https://github.com/TriPSs/conventional-changelog-action/issues/104
fixes https://github.com/TriPSs/conventional-changelog-action/issues/38
fixes https://github.com/TriPSs/conventional-changelog-action/issues/159