### PR TITLE
feat: add skip-tag to skip tagging a release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,7 @@ jobs:
           skip-commit: 'true'
           git-push: 'false'
 
-  test-git-no-tag:
+  test-skip-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,6 +286,7 @@ jobs:
           EXPECTED_TAG: 'v0.55.8'
           SKIPPED_COMMIT: true
           EXPECTED_NO_PUSH: true
+          SKIPPED_TAG: true
         with:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,6 +260,38 @@ jobs:
           skip-commit: 'true'
           git-push: 'false'
 
+  test-git-no-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+
+      - run: git tag | xargs git tag -d
+      - name: Create fake tag
+        run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+      - run: "git add . && git commit --allow-empty -m 'fix: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v0.55.8'
+          SKIPPED_COMMIT: true
+          EXPECTED_NO_PUSH: true
+        with:
+          github-token: ${{ secrets.github_token }}
+          skip-commit: 'true'
+          skip-tag: 'true'
+          git-push: 'false'
+
   test-yaml:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occurred when you push `chore` commit with `angular` for example. Default `'true'`.
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
 - **Optional** `skip-commit`: Do not create a release commit. Default `'false'`.
+- **Optional** `skip-tag`: Do not tag the release. Helpful for using action to check if a release is going to be made. Default `'false'`.
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
 - **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
 - **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
@@ -80,9 +81,11 @@ export function preTagGeneration(tag: string): string {}
 ```
 
 ### Config-File-Path
+
 A config file to define the conventional commit settings. Use it if you need to override values like `issuePrefix` or `issueUrlFormat`. If you set a `config-file-path`, the `preset` setting will be ignored. Therefore use an existing config and override the values you want to adjust.
 
 example:
+
 ```javascript
 'use strict'
 const config = require('conventional-changelog-conventionalcommits');
@@ -92,6 +95,7 @@ module.exports = config({
     "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}"
 })
 ```
+
 The specified path can be relative or absolute. If it is relative, then it will be based on the `GITHUB_WORKSPACE` path.
 
 Make sure to install all required packages in the workflow before executing this action.

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,11 @@ inputs:
     default: 'false'
     required: false
 
+  skip-tag:
+    description: 'Do not tag the release. Helpful for using action to check if a release is going to be made'
+    default: 'false'
+    required: false
+
   pre-commit:
     description: 'Path to the pre-commit script file'
     required: false

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -160,7 +160,7 @@ module.exports = new (class Git {
    */
   testHistory = (branch) => {
     if (ENV === 'dont-use-git') {
-      const { EXPECTED_TAG, SKIPPED_COMMIT, EXPECTED_NO_PUSH, SKIPPED_PULL, SKIP_CI } = process.env
+      const { EXPECTED_TAG, SKIPPED_COMMIT, EXPECTED_NO_PUSH, SKIPPED_TAG, SKIPPED_PULL, SKIP_CI } = process.env
 
       const expectedCommands = [
         'git config user.name "Conventional Changelog Action"',
@@ -181,7 +181,9 @@ module.exports = new (class Git {
         }
       }
 
-      expectedCommands.push(`git tag -a ${EXPECTED_TAG} -m "${EXPECTED_TAG}"`)
+      if(!SKIPPED_TAG) {
+        expectedCommands.push(`git tag -a ${EXPECTED_TAG} -m "${EXPECTED_TAG}"`)
+      } 
 
       if (!EXPECTED_NO_PUSH) {
         expectedCommands.push(`git push origin ${branch} --follow-tags`)

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ async function run() {
     const skipVersionFile = core.getBooleanInput('skip-version-file')
     const skipCommit = core.getBooleanInput('skip-commit')
     const skipEmptyRelease = core.getBooleanInput('skip-on-empty')
+    const skipTag = core.getBooleanInput('skip-tag')
     const conventionalConfigFile = core.getInput('config-file-path')
     const preChangelogGenerationFile = core.getInput('pre-changelog-generation')
     const gitUrl = core.getInput('git-url')
@@ -187,7 +188,10 @@ async function run() {
       }
 
       // Create the new tag
-      await git.createTag(gitTag)
+      if (!skipTag)
+        await git.createTag(gitTag)
+      else
+        core.info('We not going to the tag the GIT changes')
 
       if (gitPush) {
         try {

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ async function run() {
       }
 
       let newVersion
+      let oldVersion
 
       // If skipVersionFile or skipCommit is true we use GIT to determine the new version because
       // skipVersionFile can mean there is no version file and skipCommit can mean that the user
@@ -114,6 +115,7 @@ async function run() {
         )
 
         newVersion = versioning.newVersion
+        oldVersion = versioning.oldVersion
 
       } else {
         const files = versionFile.split(',').map((f) => f.trim())
@@ -129,6 +131,7 @@ async function run() {
         )
 
         newVersion = versioning[0].newVersion
+        oldVersion = versioning[0].oldVersion
       }
 
       let gitTag = `${tagPrefix}${newVersion}`
@@ -157,6 +160,7 @@ async function run() {
 
       if (skipEmptyRelease && cleanChangelog === '') {
         core.info('Generated changelog is empty and skip-on-empty has been activated so we skip this step')
+        core.setOutput('version', oldVersion)
         core.setOutput('skipped', 'true')
         return
       }

--- a/src/version/base.js
+++ b/src/version/base.js
@@ -9,6 +9,7 @@ module.exports = class BaseVersioning {
 
   newVersion = null
 
+  oldVersion = null
   /**
    * Set some basic configurations
    *

--- a/src/version/git.js
+++ b/src/version/git.js
@@ -17,7 +17,7 @@ module.exports = class Git extends BaseVersioning {
         // Get the new version
         this.newVersion = await bumpVersion(
           releaseType,
-          oldVersion,
+          this.oldVersion,
         )
 
         // We are done

--- a/src/version/git.js
+++ b/src/version/git.js
@@ -12,12 +12,12 @@ module.exports = class Git extends BaseVersioning {
       const prerelease = core.getBooleanInput('pre-release')
 
       gitSemverTags({ tagPrefix, skipUnstable: !prerelease }, async (err, tags) => {
-        const currentVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : null
+        this.oldVersion = tags.length > 0 ? tags.shift().replace(tagPrefix, '') : null
 
         // Get the new version
         this.newVersion = await bumpVersion(
           releaseType,
-          currentVersion,
+          oldVersion,
         )
 
         // We are done

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -30,12 +30,12 @@ module.exports = class Json extends BaseVersioning {
     }
 
     // Get the old version
-    const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
+    this.oldVersion = objectPath.get(jsonContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = await bumpVersion(
       releaseType,
-      oldVersion,
+      this.oldVersion,
     )
 
     core.info(`Bumped file "${this.fileLocation}" from "${oldVersion}" to "${this.newVersion}"`)

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -38,7 +38,7 @@ module.exports = class Json extends BaseVersioning {
       this.oldVersion,
     )
 
-    core.info(`Bumped file "${this.fileLocation}" from "${oldVersion}" to "${this.newVersion}"`)
+    core.info(`Bumped file "${this.fileLocation}" from "${this.oldVersion}" to "${this.newVersion}"`)
 
     // Update the content with the new version
     objectPath.set(jsonContent, this.versionPath, this.newVersion)

--- a/src/version/toml.js
+++ b/src/version/toml.js
@@ -30,7 +30,7 @@ module.exports = class Toml extends BaseVersioning {
       // Get the name of where the version is in
       const versionName = this.versionPath.split('.').pop()
 
-      core.info(`Bumped file "${this.fileLocation}" from "${oldVersion}" to "${this.newVersion}"`)
+      core.info(`Bumped file "${this.fileLocation}" from "${this.oldVersion}" to "${this.newVersion}"`)
 
       this.update(
         // We use replace instead of yaml.stringify so we can preserve white spaces and comments

--- a/src/version/toml.js
+++ b/src/version/toml.js
@@ -17,16 +17,16 @@ module.exports = class Toml extends BaseVersioning {
     // Read the file
     const fileContent = this.read()
     const tomlContent = toml.parse(fileContent)
-    const oldVersion = objectPath.get(tomlContent, this.versionPath, null)
+    this.oldVersion = objectPath.get(tomlContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = await bumpVersion(
       releaseType,
-      oldVersion,
+      this.oldVersion,
     )
 
     // Update the file
-    if (oldVersion) {
+    if (this.oldVersion) {
       // Get the name of where the version is in
       const versionName = this.versionPath.split('.').pop()
 
@@ -35,7 +35,7 @@ module.exports = class Toml extends BaseVersioning {
       this.update(
         // We use replace instead of yaml.stringify so we can preserve white spaces and comments
         fileContent.replace(
-          `${versionName} = "${oldVersion}"`,
+          `${versionName} = "${this.oldVersion}"`,
           `${versionName} = "${this.newVersion}"`,
         ),
       )

--- a/src/version/yaml.js
+++ b/src/version/yaml.js
@@ -30,7 +30,7 @@ module.exports = class Yaml extends BaseVersioning {
       // Get the name of where the version is in
       const versionName = this.versionPath.split('.').pop()
 
-      core.info(`Bumped file "${this.fileLocation}" from "${oldVersion}" to "${this.newVersion}"`)
+      core.info(`Bumped file "${this.fileLocation}" from "${this.oldVersion}" to "${this.newVersion}"`)
 
       this.update(
         // We use replace instead of yaml.stringify so we can preserve white spaces and comments

--- a/src/version/yaml.js
+++ b/src/version/yaml.js
@@ -17,16 +17,16 @@ module.exports = class Yaml extends BaseVersioning {
     // Read the file
     const fileContent = this.read()
     const yamlContent = yaml.parse(fileContent) || {}
-    const oldVersion = objectPath.get(yamlContent, this.versionPath, null)
+    this.oldVersion = objectPath.get(yamlContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = await bumpVersion(
       releaseType,
-      oldVersion,
+      this.oldVersion,
     )
 
     // Update the file
-    if (oldVersion) {
+    if (this.oldVersion) {
       // Get the name of where the version is in
       const versionName = this.versionPath.split('.').pop()
 
@@ -36,13 +36,13 @@ module.exports = class Yaml extends BaseVersioning {
         // We use replace instead of yaml.stringify so we can preserve white spaces and comments
         // Replace if version was used with single quotes
         fileContent.replace(
-          `${versionName}: '${oldVersion}'`,
+          `${versionName}: '${this.oldVersion}'`,
           `${versionName}: '${this.newVersion}'`,
         ).replace( // Replace if version was used with double quotes
-          `${versionName}: "${oldVersion}"`,
+          `${versionName}: "${this.oldVersion}"`,
           `${versionName}: "${this.newVersion}"`,
         ).replace( // Replace if version was used with no quotes
-          `${versionName}: ${oldVersion}`,
+          `${versionName}: ${this.oldVersion}`,
           `${versionName}: ${this.newVersion}`,
         ),
       )


### PR DESCRIPTION
I use conventional-changelog-action extensively in our repos.  One feature I extend conventional-changelog-action with is the ability to skip-tag.  This way I can do a preflight action before I build to see if I need to build.  I also output the current version if the version is not bumped.  This allows my actions to properly rely on the version output.