### PR TITLE
fix: honour pre-release flag for default version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: 'Test the action'
+name: "Test the action"
 on:
   pull_request:
     branches:
@@ -24,11 +24,11 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.json'
+          version-file: "test-file.json"
 
       - name: Show file
         run: |
@@ -38,7 +38,7 @@ jobs:
         run: node ./test-github-output.js
         env:
           TAG: ${{ steps.changelog.outputs.tag }}
-          EXPECTED_TAG: 'v1.5.0'
+          EXPECTED_TAG: "v1.5.0"
 
   test-json:
     runs-on: ubuntu-latest
@@ -58,11 +58,11 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.json'
+          version-file: "test-file.json"
 
       - name: Show file
         run: |
@@ -71,8 +71,8 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.json'
-          EXPECTED_VERSION: '1.5.0'
+          FILES: "test-file.json"
+          EXPECTED_VERSION: "1.5.0"
 
   test-json-new:
     runs-on: ubuntu-latest
@@ -92,11 +92,11 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file-new.json'
+          version-file: "test-file-new.json"
 
       - name: Show file
         run: |
@@ -105,8 +105,43 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-new.json'
-          EXPECTED_VERSION: '0.1.0'
+          FILES: "test-file-new.json"
+          EXPECTED_VERSION: "0.1.0"
+
+  test-json-new-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit --allow-empty -m 'feat: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0-rc.0"
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: "test-file-new-prerelease.json"
+          pre-release: true
+
+      - name: Show file
+        run: |
+          echo "$(<test-file-new-prerelease.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: "test-file-new-prerelease.json"
+          EXPECTED_VERSION: "0.1.0-rc.0"
 
   test-json-empty:
     runs-on: ubuntu-latest
@@ -128,19 +163,19 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: './test-file-empty.json'
+          version-file: "./test-file-empty.json"
 
       - run: echo "$(<./test-file-empty.json)"
 
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-empty.json'
-          EXPECTED_VERSION: '0.1.0'
+          FILES: "test-file-empty.json"
+          EXPECTED_VERSION: "0.1.0"
 
   test-git:
     runs-on: ubuntu-latest
@@ -164,13 +199,13 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.55.9'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.55.9"
           SKIPPED_COMMIT: true
         with:
           github-token: ${{ secrets.github_token }}
-          skip-commit: 'true'
-          
+          skip-commit: "true"
+
   test-git-no-pull:
     runs-on: ubuntu-latest
     steps:
@@ -193,14 +228,14 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.55.9'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.55.9"
           SKIPPED_COMMIT: true
           SKIPPED_PULL: true
         with:
           github-token: ${{ secrets.github_token }}
-          skip-commit: 'true'
-          skip-git-pull: 'true'
+          skip-commit: "true"
+          skip-git-pull: "true"
 
   test-git-fallback:
     runs-on: ubuntu-latest
@@ -222,12 +257,12 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
           SKIPPED_COMMIT: true
         with:
           github-token: ${{ secrets.github_token }}
-          skip-commit: 'true'
+          skip-commit: "true"
 
   test-git-no-push:
     runs-on: ubuntu-latest
@@ -251,14 +286,14 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.55.9'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.55.9"
           SKIPPED_COMMIT: true
           EXPECTED_NO_PUSH: true
         with:
           github-token: ${{ secrets.github_token }}
-          skip-commit: 'true'
-          git-push: 'false'
+          skip-commit: "true"
+          git-push: "false"
 
   test-yaml:
     runs-on: ubuntu-latest
@@ -278,32 +313,32 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v9.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v9.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.yaml'
-          version-path: 'package.version'
+          version-file: "test-file.yaml"
+          version-path: "package.version"
 
       - name: Generate changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v9.6.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v9.6.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.yaml'
-          version-path: 'package.no-quotes-version'
+          version-file: "test-file.yaml"
+          version-path: "package.no-quotes-version"
 
       - name: Generate changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v9.7.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v9.7.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.yaml'
-          version-path: 'package.double-quotes-version'
+          version-file: "test-file.yaml"
+          version-path: "package.double-quotes-version"
 
       - name: Show file
         run: |
@@ -312,23 +347,23 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.yaml'
-          EXPECTED_VERSION: '9.5.0'
-          EXPECTED_VERSION_PATH: 'package.version'
+          FILES: "test-file.yaml"
+          EXPECTED_VERSION: "9.5.0"
+          EXPECTED_VERSION_PATH: "package.version"
 
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.yaml'
-          EXPECTED_VERSION: '9.6.0'
-          EXPECTED_VERSION_PATH: 'package.no-quotes-version'
+          FILES: "test-file.yaml"
+          EXPECTED_VERSION: "9.6.0"
+          EXPECTED_VERSION_PATH: "package.no-quotes-version"
 
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.yaml'
-          EXPECTED_VERSION: '9.7.0'
-          EXPECTED_VERSION_PATH: 'package.double-quotes-version'
+          FILES: "test-file.yaml"
+          EXPECTED_VERSION: "9.7.0"
+          EXPECTED_VERSION_PATH: "package.double-quotes-version"
 
   test-yaml-new:
     runs-on: ubuntu-latest
@@ -350,12 +385,12 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file-new.yaml'
-          version-path: 'package.version'
+          version-file: "test-file-new.yaml"
+          version-path: "package.version"
 
       - name: Show file
         run: |
@@ -364,9 +399,9 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-new.yaml'
-          EXPECTED_VERSION: '0.1.0'
-          EXPECTED_VERSION_PATH: 'package.version'
+          FILES: "test-file-new.yaml"
+          EXPECTED_VERSION: "0.1.0"
+          EXPECTED_VERSION_PATH: "package.version"
 
   test-yaml-empty:
     runs-on: ubuntu-latest
@@ -386,12 +421,12 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: './test-file-empty.yaml'
-          version-path: 'package.version'
+          version-file: "./test-file-empty.yaml"
+          version-path: "package.version"
 
       - name: Show file
         run: |
@@ -400,9 +435,9 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-empty.yaml'
-          EXPECTED_VERSION: '0.1.0'
-          EXPECTED_VERSION_PATH: 'package.version'
+          FILES: "test-file-empty.yaml"
+          EXPECTED_VERSION: "0.1.0"
+          EXPECTED_VERSION_PATH: "package.version"
 
   test-toml:
     runs-on: ubuntu-latest
@@ -422,12 +457,12 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.10.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.10.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.toml'
-          version-path: 'package.version'
+          version-file: "test-file.toml"
+          version-path: "package.version"
 
       - name: Show file
         run: |
@@ -436,9 +471,9 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.toml'
-          EXPECTED_VERSION: '0.10.0'
-          EXPECTED_VERSION_PATH: 'package.version'
+          FILES: "test-file.toml"
+          EXPECTED_VERSION: "0.10.0"
+          EXPECTED_VERSION_PATH: "package.version"
 
   test-toml-new:
     runs-on: ubuntu-latest
@@ -458,12 +493,12 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file-new.toml'
-          version-path: 'package.version'
+          version-file: "test-file-new.toml"
+          version-path: "package.version"
 
       - name: Show file
         run: |
@@ -472,9 +507,9 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-new.toml'
-          EXPECTED_VERSION: '0.1.0'
-          EXPECTED_VERSION_PATH: 'package.version'
+          FILES: "test-file-new.toml"
+          EXPECTED_VERSION: "0.1.0"
+          EXPECTED_VERSION_PATH: "package.version"
 
   test-toml-empty:
     runs-on: ubuntu-latest
@@ -496,13 +531,13 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v6.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v6.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: './test-file-empty.toml'
-          version-path: 'package.version'
-          fallback-version: '6.5.0'
+          version-file: "./test-file-empty.toml"
+          version-path: "package.version"
+          fallback-version: "6.5.0"
 
       - name: Show file
         run: |
@@ -511,9 +546,9 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-empty.toml'
-          EXPECTED_VERSION: '6.5.0'
-          EXPECTED_VERSION_PATH: 'package.version'
+          FILES: "test-file-empty.toml"
+          EXPECTED_VERSION: "6.5.0"
+          EXPECTED_VERSION_PATH: "package.version"
 
   test-pre-commit:
     runs-on: ubuntu-latest
@@ -535,13 +570,13 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          pre-commit: './test-pre-commit.js'
-          skip-on-empty: 'false'
-          version-file: './test-file.json'
+          pre-commit: "./test-pre-commit.js"
+          skip-on-empty: "false"
+          version-file: "./test-file.json"
 
       - run: test -f pre-commit.test.json || (echo should be here && exit 1)
       - run: cat pre-commit.test.json && echo ""
@@ -567,13 +602,13 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.0.100-alpha'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.0.100-alpha"
         with:
           github-token: ${{ secrets.github_token }}
-          pre-changelog-generation: './test-pre-changelog-generation.js'
-          version-file: './test-file.toml'
-          version-path: 'package.version'
+          pre-changelog-generation: "./test-pre-changelog-generation.js"
+          version-file: "./test-file.toml"
+          version-path: "package.version"
 
       - run: test -f pre-changelog-generation.version.test.json || (echo should be here && exit 1)
       - run: test -f pre-changelog-generation.tag.test.json || (echo should be here && exit 1)
@@ -599,11 +634,11 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.json, test-file-2.json, test-file.toml, test-file.yaml'
+          version-file: "test-file.json, test-file-2.json, test-file.toml, test-file.yaml"
 
       - name: Show files
         run: |
@@ -619,8 +654,8 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.json, test-file-2.json, test-file.toml, test-file.yaml'
-          EXPECTED_VERSION: '1.5.0, 1.5.0, 1.5.0, 1.11.0'
+          FILES: "test-file.json, test-file-2.json, test-file.toml, test-file.yaml"
+          EXPECTED_VERSION: "1.5.0, 1.5.0, 1.5.0, 1.11.0"
 
   test-config-file-path:
     runs-on: ubuntu-latest
@@ -640,12 +675,12 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.1.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v0.1.0"
         with:
           github-token: ${{ secrets.github_token }}
-          skip-version-file: 'true'
-          config-file-path: './test-changelog.config.js'
+          skip-version-file: "true"
+          config-file-path: "./test-changelog.config.js"
 
       - name: Test output
         run: |
@@ -654,7 +689,6 @@ jobs:
           else
             echo "Changelog config not applied" && exit 1
           fi
-
 
   test-skip-ci:
     runs-on: ubuntu-latest
@@ -674,13 +708,13 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.5.0'
-          SKIP_CI: 'false'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.5.0"
+          SKIP_CI: "false"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.json'
-          skip-ci: 'false'
+          version-file: "test-file.json"
+          skip-ci: "false"
 
       - name: Show file
         run: |
@@ -689,8 +723,8 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.json'
-          EXPECTED_VERSION: '1.5.0'
+          FILES: "test-file.json"
+          EXPECTED_VERSION: "1.5.0"
 
   test-pre-release:
     runs-on: ubuntu-latest
@@ -710,11 +744,11 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.4.6-rc.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.4.6-rc.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.json'
+          version-file: "test-file.json"
           pre-release: true
 
       - name: Show file
@@ -724,8 +758,8 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.json'
-          EXPECTED_VERSION: '1.4.6-rc.0'
+          FILES: "test-file.json"
+          EXPECTED_VERSION: "1.4.6-rc.0"
 
   test-pre-release-identifier:
     runs-on: ubuntu-latest
@@ -745,13 +779,13 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.4.6-alpha.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.4.6-alpha.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file.json'
+          version-file: "test-file.json"
           pre-release: true
-          pre-release-identifier: 'alpha'
+          pre-release-identifier: "alpha"
 
       - name: Show file
         run: |
@@ -760,8 +794,8 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file.json'
-          EXPECTED_VERSION: '1.4.6-alpha.0'
+          FILES: "test-file.json"
+          EXPECTED_VERSION: "1.4.6-alpha.0"
 
   test-pre-release-to-stable:
     runs-on: ubuntu-latest
@@ -781,11 +815,11 @@ jobs:
         id: changelog
         uses: ./
         env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.5.0'
+          ENV: "dont-use-git"
+          EXPECTED_TAG: "v1.5.0"
         with:
           github-token: ${{ secrets.github_token }}
-          version-file: 'test-file-pre-release.json'
+          version-file: "test-file-pre-release.json"
           pre-release: false # This is the default value, but we want to be explicit
 
       - name: Show file
@@ -795,5 +829,5 @@ jobs:
       - name: Test output
         run: node ./test-output.js
         env:
-          FILES: 'test-file-pre-release.json'
-          EXPECTED_VERSION: '1.5.0'
+          FILES: "test-file-pre-release.json"
+          EXPECTED_VERSION: "1.5.0"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.
 - **Optional** `skip-commit`: Do not create a release commit. Default `'false'`.
 - **Optional** `pre-commit`: Path to the pre-commit script file. No hook by default.
-- **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
+- **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`. If `pre-release`is set to `true` it will default to the configured pre-release format (i.e. `'0.1.0-rc.0'`)
 - **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
 - **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
 - **Optional** `skip-ci`: Adds instruction to Github to not consider the push something to rebuild. Default `true`.

--- a/action.yml
+++ b/action.yml
@@ -1,156 +1,155 @@
-name: 'Conventional Changelog Action'
-description: 'Bump version, tag commit and generates changelog with conventional commits.'
-author: 'Tycho Bokdam'
+name: "Conventional Changelog Action"
+description: "Bump version, tag commit and generates changelog with conventional commits."
+author: "Tycho Bokdam"
 
 runs:
-  using: 'node16'
-  main: 'src/index.js'
+  using: "node16"
+  main: "src/index.js"
 
 branding:
-  icon: 'edit'
-  color: 'red'
+  icon: "edit"
+  color: "red"
 
 inputs:
   github-token:
-    description: 'Github token'
+    description: "Github token"
     default: ${{ github.token }}
     required: false
 
   git-message:
-    description: 'Commit message to use'
-    default: 'chore(release): {version}'
+    description: "Commit message to use"
+    default: "chore(release): {version}"
     required: false
 
   git-user-name:
-    description: 'The git user.name to use for the commit'
-    default: 'Conventional Changelog Action'
+    description: "The git user.name to use for the commit"
+    default: "Conventional Changelog Action"
     required: false
 
   git-user-email:
-    description: 'The git user.email to use for the commit'
-    default: 'conventional.changelog.action@github.com'
+    description: "The git user.email to use for the commit"
+    default: "conventional.changelog.action@github.com"
     required: false
 
   git-pull-method:
-    description: 'The git pull method used when pulling all changes from remote'
-    default: '--ff-only'
+    description: "The git pull method used when pulling all changes from remote"
+    default: "--ff-only"
     required: false
 
   git-push:
-    description: 'Should all the git changes be push'
-    default: 'true'
+    description: "Should all the git changes be push"
+    default: "true"
     required: false
 
   git-branch:
-    description: 'The git branch to be pushed'
+    description: "The git branch to be pushed"
     default: ${{ github.ref }}
     required: false
 
   preset:
-    description: 'The preset from Conventional Changelog to use'
-    default: 'angular'
+    description: "The preset from Conventional Changelog to use"
+    default: "angular"
     required: false
 
   tag-prefix:
-    description: 'Prefix that is used for the git tag'
-    default: 'v'
+    description: "Prefix that is used for the git tag"
+    default: "v"
     required: false
 
   output-file:
-    description: 'File to output the changelog to'
-    default: 'CHANGELOG.md'
+    description: "File to output the changelog to"
+    default: "CHANGELOG.md"
     required: false
 
   release-count:
-    description: 'Number of releases to preserve in changelog'
-    default: '5'
+    description: "Number of releases to preserve in changelog"
+    default: "5"
     required: false
 
   version-file:
-    description: 'The path to the file that contains the version to bump (supports comma-separated list of file paths)'
-    default: './package.json'
+    description: "The path to the file that contains the version to bump (supports comma-separated list of file paths)"
+    default: "./package.json"
     required: false
 
   version-path:
-    description: 'The place inside the version file to bump'
-    default: 'version'
+    description: "The place inside the version file to bump"
+    default: "version"
     required: false
 
   skip-git-pull:
-    description: 'Do not pull the repo before tagging. Ensure you full cloned the repo in the first place to get tags'
-    default: 'false'
+    description: "Do not pull the repo before tagging. Ensure you full cloned the repo in the first place to get tags"
+    default: "false"
     required: false
 
   skip-on-empty:
-    description: 'Do nothing when the changelog from the latest release is empty'
-    default: 'true'
+    description: "Do nothing when the changelog from the latest release is empty"
+    default: "true"
     required: false
 
   skip-version-file:
-    description: 'Do not update the version file'
-    default: 'false'
+    description: "Do not update the version file"
+    default: "false"
     required: false
 
   skip-commit:
-    description: 'Do create a release commit'
-    default: 'false'
+    description: "Do create a release commit"
+    default: "false"
     required: false
 
   pre-commit:
-    description: 'Path to the pre-commit script file'
+    description: "Path to the pre-commit script file"
     required: false
 
   fallback-version:
-    description: 'The fallback version, if no older one can be detected, or if it is the first one'
-    default: '0.1.0'
+    description: "The fallback version, if no older one can be detected, or if it is the first one"
     required: false
 
   config-file-path:
-    description: 'Path to the conventional changelog config file. If set, the preset setting will be ignored'
+    description: "Path to the conventional changelog config file. If set, the preset setting will be ignored"
     required: false
 
   pre-changelog-generation:
-    description: 'Path to the pre-changelog-generation script file'
+    description: "Path to the pre-changelog-generation script file"
     required: false
 
   git-url:
-    description: 'Git Url'
-    default: 'github.com'
+    description: "Git Url"
+    default: "github.com"
     required: false
 
   git-path:
-    description: 'Path filter for the logs. If set, only commits that match the path filter will be considered'
-    default: ''
+    description: "Path filter for the logs. If set, only commits that match the path filter will be considered"
+    default: ""
     required: false
 
   skip-ci:
-    description: 'Adds [skip ci] to commit message, to avoid triggering a new build'
-    default: 'true'
+    description: "Adds [skip ci] to commit message, to avoid triggering a new build"
+    default: "true"
     required: false
 
   create-summary:
-    description: 'Adds the generated changelog as Action Summary'
-    default: 'false'
+    description: "Adds the generated changelog as Action Summary"
+    default: "false"
     required: false
 
   pre-release:
-    description: 'Marks the release as pre-release'
-    default: 'false'
+    description: "Marks the release as pre-release"
+    default: "false"
     required: false
 
   pre-release-identifier:
-    description: 'The identifier to use for pre-releases'
-    default: 'rc'
+    description: "The identifier to use for pre-releases"
+    default: "rc"
     required: false
 
 outputs:
   changelog:
-    description: 'The generated changelog for the new version'
+    description: "The generated changelog for the new version"
   clean_changelog:
-    description: 'The generated changelog for the new version without the version name in it'
+    description: "The generated changelog for the new version without the version name in it"
   version:
-    description: 'The new version'
+    description: "The new version"
   tag:
-    description: 'The name of the generated tag'
+    description: "The name of the generated tag"
   skipped:
-    description: 'boolean to check if this step have been skipped'
+    description: "boolean to check if this step have been skipped"

--- a/src/helpers/bumpVersion.js
+++ b/src/helpers/bumpVersion.js
@@ -19,11 +19,14 @@ module.exports = async (releaseType, version) => {
   if (version) {
     newVersion = semver.inc(version, (prerelease ? 'prerelease' : releaseType), identifier)
   } else {
-    let version = semver.valid(core.getInput('fallback-version'))
 
-    if (version) {
-      newVersion = version
-    } else {
+    const fallbackVersion = core.getInput('fallback-version')
+
+    if (fallbackVersion) {
+      newVersion = semver.valid(fallbackVersion)
+    }
+
+    if (!newVersion) {
       // default
       newVersion = (prerelease ? `0.1.0-${identifier}.0` : '0.1.0')
     }

--- a/src/helpers/bumpVersion.js
+++ b/src/helpers/bumpVersion.js
@@ -25,7 +25,7 @@ module.exports = async (releaseType, version) => {
       newVersion = version
     } else {
       // default
-      newVersion = '0.1.0'
+      newVersion = (prerelease ? `0.1.0-${identifier}.0` : '0.1.0')
     }
 
     core.info(`The version could not be detected, using fallback version '${newVersion}'.`)


### PR DESCRIPTION
if there is no previous version and no explicit fallback version is specified emit a pre-release version (0.1.0-rc.0 by default) if the pre-release flag is true.

fixes #190