### PR TITLE
fix: execute git config commands synchronously

### DIFF
--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -14,35 +14,34 @@ module.exports = new (class Git {
     // Make the Github token secret
     core.setSecret(githubToken)
 
-    const gitUserName = core.getInput('git-user-name')
-    const gitUserEmail = core.getInput('git-user-email')
-    const gitUrl = core.getInput('git-url')
-
     // if the env is dont-use-git then we mock exec as we are testing a workflow
     if (ENV === 'dont-use-git') {
       this.exec = (command) => {
         const fullCommand = `git ${command}`
-
+        
         console.log(`Skipping "${fullCommand}" because of test env`)
-
+        
         if (!fullCommand.includes('git remote set-url origin')) {
           this.commandsRun.push(fullCommand)
         }
       }
     }
+  }
 
-    // use a self-invoking async function to await promises inside a constructor
-    // this avoids git config lock errors which are triggered when multiple `git config` commands are run
-    (async () => {
-      // Set config
-      await this.config('user.name', gitUserName)
-      await this.config('user.email', gitUserEmail)
+  init = async () => {
+    const gitUserName = core.getInput('git-user-name')
+    const gitUserEmail = core.getInput('git-user-email')
+    const gitUrl = core.getInput('git-url')
+    const githubToken = core.getInput('github-token')
 
-      // Update the origin
-      if (githubToken) {
-        await this.updateOrigin(`https://x-access-token:${githubToken}@${gitUrl}/${GITHUB_REPOSITORY}.git`)
-      }
-    })()
+    // Set config
+    await this.config('user.name', gitUserName)
+    await this.config('user.email', gitUserEmail)
+
+    // Update the origin
+    if (githubToken) {
+      await this.updateOrigin(`https://x-access-token:${githubToken}@${gitUrl}/${GITHUB_REPOSITORY}.git`)
+    }
   }
 
   /**

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -31,14 +31,18 @@ module.exports = new (class Git {
       }
     }
 
-    // Set config
-    this.config('user.name', gitUserName)
-    this.config('user.email', gitUserEmail)
+    // use a self-invoking async function to await promises inside a constructor
+    // this avoids git config lock errors which are triggered when multiple `git config` commands are run
+    (async () => {
+      // Set config
+      await this.config('user.name', gitUserName)
+      await this.config('user.email', gitUserEmail)
 
-    // Update the origin
-    if (githubToken) {
-      this.updateOrigin(`https://x-access-token:${githubToken}@${gitUrl}/${GITHUB_REPOSITORY}.git`)
-    }
+      // Update the origin
+      if (githubToken) {
+        await this.updateOrigin(`https://x-access-token:${githubToken}@${gitUrl}/${GITHUB_REPOSITORY}.git`)
+      }
+    })()
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,8 @@ async function run() {
     core.info(`Skipping empty releases is "${skipEmptyRelease ? 'enabled' : 'disabled'}"`)
     core.info(`Skipping the update of the version file is "${skipVersionFile ? 'enabled' : 'disabled'}"`)
 
+    await git.init()
+
     if (!skipGitPull) {
       core.info('Pull to make sure we have the full git history')
       await git.pull()


### PR DESCRIPTION
this fixes the following error I was running into:

```
error: could not lock config file .git/config: File exists
```
