### PR TITLE
fix: push only tags when skip-commit and git-push

### DIFF
--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -127,6 +127,10 @@ module.exports = new (class Git {
     this.exec(`push origin ${branch} --follow-tags`)
   )
 
+  pushTags = () => (
+    this.exec('push origin --tags')
+  )
+
   /**
    * Check if the repo is shallow
    *

--- a/src/index.js
+++ b/src/index.js
@@ -201,8 +201,13 @@ async function run() {
 
       if (gitPush) {
         try {
-          core.info('Push all changes')
-          await git.push(gitBranch)
+          if (!skipCommit) {
+            core.info('Push all changes')
+            await git.push(gitBranch)
+          } else {
+            core.info('Push tags')
+            await git.pushTags()
+          }
 
         } catch (error) {
           console.error(error)


### PR DESCRIPTION
There's an edge case where if skip-commit is true as well as git-push, and you follow the instructions for skipping git pull and a commit gets pushed to the branch while this is running, that it will fail the job. This is because when pushing the results, it would also push the branch. Pushing the branch isn't necessary though. This doesn't fix the edge case though if skip-commit is false but you'd likely want that to fail then in that case.

