### PR TITLE
Support git-path config option for version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `git-push`: Push all the GIT changes. Default `true`
 - **Optional** `git-branch`: The branch used to push. Default is the current branch (`${{ github.ref }}`)
 - **Optional** `git-url`: Git repository domain. Default is `github.com`
-- **Optional** `git-path`: Path filter for the logs. If set, only commits that match the path filter will be considered. By default, we won't use this feature(empty string).
+- **Optional** `git-path`: Path filter for the logs and version. If set, only commits that match the path filter will be considered. By default, we won't use this feature(empty string).
 - **Optional** `preset`: Preset that is used from conventional commits. Default is `angular` ([learn more about presents here](https://github.com/TriPSs/conventional-changelog-action/issues/223))
 - **Optional** `tag-prefix`: Prefix for the git tags. Default `v`.
 - **Optional** `input-file`: Read the changelog from this file. This will prepend the newly generated changelogs to the file's content.

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ inputs:
     required: false
 
   git-path:
-    description: "Path filter for the logs. If set, only commits that match the path filter will be considered"
+    description: "Path filter for the logs and version. If set, only commits that match the path filter will be considered"
     default: ""
     required: false
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -34885,7 +34885,8 @@ async function run() {
       preset: await loadPreset(preset),
       tagPrefix,
       config,
-      skipUnstable: !prerelease
+      skipUnstable: !prerelease,
+      path: gitPath
     })
 
     core.info(`Recommended release type: ${recommendation.releaseType}`)

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,8 @@ async function run() {
       preset: await loadPreset(preset),
       tagPrefix,
       config,
-      skipUnstable: !prerelease
+      skipUnstable: !prerelease,
+      path: gitPath
     })
 
     core.info(`Recommended release type: ${recommendation.releaseType}`)


### PR DESCRIPTION
I found that, while the git-path config option does correctly limit changelog generation to commits that fall within the path, the version bump still considers all paths. 'conventional-recommended-bump' [supports a `path` option](https://www.npmjs.com/package/conventional-recommended-bump#path), so it is not difficult to support this.