### PR TITLE
Wait for Required Checks on Protected Branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ A config file to define the conventional commit settings. Use it if you need to 
 example:
 
 ```javascript
-'use strict';
+'use strict'
 const config = require('conventional-changelog-conventionalcommits');
 
 module.exports = config({
-  "issuePrefixes": ["TN-"],
-  "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}",
+    "issuePrefixes": ["TN-"],
+    "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}",
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `pre-release`: Marks the release as pre-release. Default `false`.
 - **Optional** `pre-release-identifier`: The identifier to use for the pre-release. Default `rc`.
 - **Optional** `skip-bump`: Prevents the action from bumping the version.
+- **Optional** `is-protected-branch`: If set to `true`, the action will wait for required checks to pass before proceeding. Default `false`.
 
 ### Presets
+
 This action comes pre-compiled with the `angular` (default) and `conventionalcommits`, if you wish to use an other preset
 you need to make sure it's installed with `npm install conventional-changelog-<preset name>`
 
@@ -93,13 +95,13 @@ A config file to define the conventional commit settings. Use it if you need to 
 example:
 
 ```javascript
-'use strict'
-const config = require('conventional-changelog-conventionalcommits');
+"use strict";
+const config = require("conventional-changelog-conventionalcommits");
 
 module.exports = config({
-    "issuePrefixes": ["TN-"],
-    "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}"
-})
+  issuePrefixes: ["TN-"],
+  issueUrlFormat: "https://jira.example.com/browse/{{prefix}}{{id}}",
+});
 ```
 
 The specified path can be relative or absolute. If it is relative, then it will be based on the `GITHUB_WORKSPACE` path.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `is-protected-branch`: If set to `true`, the action will wait for required checks to pass before proceeding. Default `false`.
 
 ### Presets
-
 This action comes pre-compiled with the `angular` (default) and `conventionalcommits`, if you wish to use an other preset
 you need to make sure it's installed with `npm install conventional-changelog-<preset name>`
 
@@ -100,7 +99,7 @@ const config = require('conventional-changelog-conventionalcommits');
 
 module.exports = config({
     "issuePrefixes": ["TN-"],
-    "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}",
+    "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}"
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ A config file to define the conventional commit settings. Use it if you need to 
 example:
 
 ```javascript
-"use strict";
-const config = require("conventional-changelog-conventionalcommits");
+'use strict';
+const config = require('conventional-changelog-conventionalcommits');
 
 module.exports = config({
-  issuePrefixes: ["TN-"],
-  issueUrlFormat: "https://jira.example.com/browse/{{prefix}}{{id}}",
-});
+  "issuePrefixes": ["TN-"],
+  "issueUrlFormat": "https://jira.example.com/browse/{{prefix}}{{id}}",
+})
 ```
 
 The specified path can be relative or absolute. If it is relative, then it will be based on the `GITHUB_WORKSPACE` path.


### PR DESCRIPTION
## Description
This PR adds functionality to wait for all required checks to pass before pushing changes when operating on a protected branch. This enhancement improves the reliability of our conventional changelog action, especially in environments with strict branch protection rules.

## Changes
- Added a new input `is-protected-branch` to indicate if the current branch is protected.
- Implemented a `waitForRequiredChecks` function to poll the status of required checks.
- Modified the main `run` function to incorporate the waiting logic when pushing to a protected branch.
- Updated the README to document the new `is-protected-branch` input.

## How to Use
To enable this feature, set the `is-protected-branch` input to `true` in your workflow: