### PR TITLE
fix: pass skipUnstable to file changelog generation

### DIFF
--- a/src/helpers/generateChangelog.js
+++ b/src/helpers/generateChangelog.js
@@ -69,12 +69,13 @@ module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCou
  * @param releaseCount
  * @param config
  * @param gitPath
+ * @param skipUnstable
  * @param infile
  * @returns {Promise<>}
  */
-module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, config, gitPath, infile) => new Promise(async(resolve) => {
+module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, config, gitPath, skipUnstable, infile) => new Promise(async(resolve) => {
   const changelogStream = await getChangelogStream(tagPrefix, preset, version, infile ? 1
-    : releaseCount, config, gitPath)
+    : releaseCount, config, gitPath, skipUnstable)
 
   // The default changelog output to be streamed first
   const readStreams = [changelogStream]

--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ async function run() {
     // If output file === 'false' we don't write it to file
     if (outputFile !== 'false') {
       // Generate the changelog
-      await changelog.generateFileChangelog(tagPrefix, preset, newVersion, outputFile, releaseCount, config, gitPath, infile)
+      await changelog.generateFileChangelog(tagPrefix, preset, newVersion, outputFile, releaseCount, config, gitPath, !prerelease, infile)
     }
 
     if (!skipCommit) {


### PR DESCRIPTION
close #294 

This pull request updates the changelog generation logic to support skipping unstable (prerelease) versions when generating the changelog file. The main change is the addition of a `skipUnstable` parameter that is passed through the codebase to control this behavior.

Changelog generation improvements:

* Added a `skipUnstable` parameter to the `generateFileChangelog` function in `generateChangelog.js` to allow skipping unstable (prerelease) versions during changelog generation.
* Updated the call to `generateFileChangelog` in `index.js` to pass `!prerelease` as the `skipUnstable` argument, ensuring that unstable releases are skipped when appropriate.